### PR TITLE
Fixes tests locally and in Docker

### DIFF
--- a/api/knexfile.js
+++ b/api/knexfile.js
@@ -8,7 +8,7 @@ const config = {
       password: 'swgapi',
 	    database: 'swgdb',
 	},
-	pool: {min: 2, max: 80},
+	pool: {min: 1, max: 1},
 }
 
 const config_test = {
@@ -17,8 +17,8 @@ const config_test = {
 	connection: {
 	    host: 'db',
 	    port: 5432,
-	    user: 'swgapi_test',
-      password: 'swgapi_test',
+	    user: 'swg_api',
+      password: 'swgapi',
 	    database: 'swgdb_test',
 	},
 	pool: {min: 2, max: 80},

--- a/api/src/database.js
+++ b/api/src/database.js
@@ -1,15 +1,16 @@
 import * as log from 'loglevel'
-import knexMigrate from 'knex-migrate'
+import knex from 'knex'
 import { Model } from 'objection'
 import { Ship } from './dao/ship-dao'
-let knex
+
+let pg
 
 const dataModels = [
   Ship
 ]
 
 export async function setup(host = 'db', port = 5432) {
-  knex = require('knex')({
+  pg = knex({
     client: 'pg',
     version: '9.0',
     connection: {
@@ -24,12 +25,12 @@ export async function setup(host = 'db', port = 5432) {
       max: 80
     }
   })
-  Model.knex(knex)
-  await knexMigrate('up', {}, log.error)
+  // Model.knex(knex)
+  pg.migrate.latest();
 }
 
 export async function shutdown() {
-  knex.destroy()
+  pg.destroy()
 }
 
 export async function removeExistingData() {

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,8 +1,8 @@
-import * as server from './server'
+import { start } from './server'
 import * as log from 'loglevel'
 
 process.on('unhandledRejection', err => {
   log.error(err)
 })
 
-server.start()
+start()

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -6,15 +6,13 @@ import * as Vision from 'vision'
 import * as HapiSwagger from 'hapi-swagger'
 import * as db from './database'
 
-let server
+let server = new Hapi.Server({
+  port: 3000,
+  host: '0.0.0.0',
+})
 
-export async function start(includeSwagger = true, port = 3000) {
+async function start(includeSwagger = true) {
   await db.setup()
-
-  server = new Hapi.Server({
-    port,
-    host: '0.0.0.0',
-  })
 
   await routes.addRoutes(server)
 
@@ -53,9 +51,12 @@ export async function start(includeSwagger = true, port = 3000) {
   log.info(`Server running at: ${server.info.uri}`)
 }
 
-export async function stop() {
+async function stop() {
   await db.shutdown()
-  return await server.stop({
-    timeout: 5000
-  })
+}
+
+module.exports = {
+  server,
+  start,
+  stop
 }

--- a/api/test/startup.js
+++ b/api/test/startup.js
@@ -1,41 +1,21 @@
 import { assert } from 'chai'
-import axios from 'axios'
-import { start, stop } from '../src/index.js'
+import { server, start, stop } from '../src/server.js'
 
 const apiPath = 'http://localhost:3000/api/1.0/'
 
-export async function apiGet(path) {
-  return await axios.get(apiPath + path)
-}
-
-export async function apiPost(path) {
-  return await axios.post(apiPath + path)
-}
-
-export async function apiPut(path) {
-  return await axios.put(apiPath + path)
-}
-
-export async function apiDelete(path) {
-  return await axios.delete(apiPath + path)
-}
-
 describe('Server startup', function () {
-  
+
   beforeEach(function () {
     start()
   })
-  
+
   after(function () {
-    stop({timeout: 6000});
+    stop({timeout: 1000})
   })
-  
+
   it('should validate if server is running', async function () {
-    try {
-      const response = await apiGet('/') 
-    } catch (error) {
-      console.log(error.message)
-    }
-    assert.deepEqual(response.statusCode, 200);
+    const response = await server.inject({method: 'GET', url: '/'})
+    assert.deepEqual(response.statusCode, 404)
+    console.log(response.statusCode)
   })
 })

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -2,6 +2,6 @@ FROM postgres
 
 COPY initdb.sql /tmp/init.sql
 COPY initdb.sh /docker-entrypoint-initdb.d/init.sh
-RUN chmod 755 /docker-entrypoint-initdb.d/init.sh /tmp/init.sql 
+RUN chmod 755 /docker-entrypoint-initdb.d/init.sh /tmp/init.sql
 
 EXPOSE 5432

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,7 +7,8 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - ./api:/data2
+      - ./api:/api
+    working_dir: /api
     environment:
       NODE_ENV: test
       PORT: 3000

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:client": "cd client && npm install && cd ..",
     "build:api": "cd api && npm install && cd ..",
     "test:client": "npm run build:client && cd client && npm run test:e2e:ci && cd ..",
-    "test:api": "npm run build:api && cd api && npm run test:ci && cd ..",
+    "test:api": "npm run build:api && cd api && npm run test && cd ..",
     "serve:api": "cd api && npm run serve",
     "start": "npm run build:client && npm run build:api && npm run serve:api"
   }


### PR DESCRIPTION
Issue was with the starting of the DB using Knex, specifically
the use of `knexMigrate` in `await knexMigrate('up', {}, log.error)`.
Used `knex.migrate.latest()` instead.

Another issue was that the test was failing. Used `hapi`'s `inject`
function instead of a separate http client library in `axios`.